### PR TITLE
fix: correcting snapper overlay scaling (Fixes #1)

### DIFF
--- a/VoilaTile.Snapper/VoilaTile.Snapper.csproj
+++ b/VoilaTile.Snapper/VoilaTile.Snapper.csproj
@@ -7,7 +7,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-	 <DpiAwareness>PerMonitorV2</DpiAwareness>
 	<ApplicationIcon>Assets\icon-logo.ico</ApplicationIcon>
 	<ApplicationManifest>Properties\app.manifest</ApplicationManifest>
     <DpiAwareness>PerMonitorV2</DpiAwareness>


### PR DESCRIPTION
Problems:
- tile layout on overlay uses physical pixels (for simplicity), which did not match with DIP in the cases when monitor hosting
the (0,0) point in screen coordinates (starting location for overlays) is set to non-100% scale

Fixes:
- applied a scale transform to the root layout container of the overlay views based on the ratio of standard dpi to the dpi used by WPF for the specific overlay window (looked up programmatically at runtime)

Testing:
- 2-monitor setup: (125, 150)% scaling
- Verified overlay alignment and snapping across multiple targets and destinations

