### PR TITLE
fix: correcting configurator layout editior initialization (Fixes #5)

### DIFF
--- a/VoilaTile.Configurator/Helpers/LayoutEditorManager.cs
+++ b/VoilaTile.Configurator/Helpers/LayoutEditorManager.cs
@@ -52,6 +52,7 @@
             };
 
             editor.Show();
+            editor.Initialize();
         }
 
         private static void ApplyBoundsPx(Window window, int x, int y, int width, int height)

--- a/VoilaTile.Configurator/Helpers/OverlayManager.cs
+++ b/VoilaTile.Configurator/Helpers/OverlayManager.cs
@@ -30,12 +30,13 @@
             HideOverlay();
 
             var owner = Application.Current.MainWindow;
+            bool isSameMonitor = MonitorUtils.IsSameMonitor(owner, monitor.MonitorInfo);
 
             var overlay = new MonitorOverlayWindow
             {
                 DataContext = monitor.SelectedTemplate,
                 ShowActivated = false,
-                Topmost = false,
+                Topmost = !isSameMonitor,
                 WindowStartupLocation = WindowStartupLocation.Manual,
                 Width = 1,
                 Height = 1,
@@ -58,12 +59,6 @@
             };
 
             overlay.Show();
-
-            bool isSameMonitor = MonitorUtils.IsSameMonitor(owner, monitor.MonitorInfo);
-            if (isSameMonitor)
-                owner.Activate();
-            else
-                WindowZOrderHelper.PlaceWindowBelow(overlay, owner);
         }
 
         public static void HideOverlay()

--- a/VoilaTile.Configurator/Helpers/WindowEx.cs
+++ b/VoilaTile.Configurator/Helpers/WindowEx.cs
@@ -1,4 +1,4 @@
-﻿namespace Configurator.Helpers
+﻿namespace VoilaTile.Configurator.Helpers
 {
     using System;
     using System.Runtime.InteropServices;

--- a/VoilaTile.Configurator/MainWindow.xaml
+++ b/VoilaTile.Configurator/MainWindow.xaml
@@ -5,8 +5,14 @@
         xmlns:vm="clr-namespace:VoilaTile.Configurator.ViewModels"
         xmlns:views="clr-namespace:VoilaTile.Configurator.Views"
         xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework"
-        Height="1024" Width="768"
-        WindowStyle="None" AllowsTransparency="True" Background="Transparent" Topmost="True" WindowStartupLocation="CenterScreen">
+        MaxHeight="{Binding Source={x:Static SystemParameters.WorkArea}, Path=Height}"
+        MaxWidth="{Binding Source={x:Static SystemParameters.WorkArea}, Path=Width}"
+        SizeToContent="WidthAndHeight"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        Topmost="True"
+        WindowStartupLocation="CenterScreen">
 
     <Window.Resources>
         <shell:WindowChrome x:Key="CustomChrome"
@@ -21,224 +27,230 @@
         <StaticResource ResourceKey="CustomChrome"/>
     </shell:WindowChrome.WindowChrome>
 
-    <Grid Background="{StaticResource BackgroundDarkGray}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="40"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
+    <Viewbox>
+        <Grid
+            Width="768"
+            Height="1024"
+            Background="{StaticResource BackgroundDarkGray}">
 
-        <!-- Custom Title Bar -->
-        <Border Grid.Row="0" Height="40" Background="{StaticResource BackgroundMediumLightGray}" MouseLeftButtonDown="OnTitleBarMouseLeftButtonDown">
-            <DockPanel LastChildFill="True">
-                <!-- Title Logo -->
-                <views:TitleLogo Height="20" Margin="10,0,0,0"/>
-
-                <!-- Window Buttons -->
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button Content="–" Foreground="{StaticResource TextWhite}" FontSize="18" Width="40" BorderBrush="Transparent" Click="OnClickMinimize">
-                        <Button.Template>
-                            <ControlTemplate TargetType="Button">
-                                <Border x:Name="minimizeBorder"
-                                        Background="Transparent"
-                                        BorderThickness="0"
-                                        BorderBrush="Transparent">
-                                    <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                </Border>
-                                <ControlTemplate.Triggers>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter TargetName="minimizeBorder" Property="Background" Value="{StaticResource BackgroundLightGray}"/>
-                                    </Trigger>
-                                    <Trigger Property="IsPressed" Value="True">
-                                        <Setter TargetName="minimizeBorder" Property="Background" Value="{StaticResource BackgroundMediumLightGray}"/>
-                                    </Trigger>
-                                </ControlTemplate.Triggers>
-                            </ControlTemplate>
-                        </Button.Template>
-                    </Button>
-                    <Button Content="☐" Foreground="{StaticResource TextWhite}" FontSize="16"  Width="40" Click="OnClickMaximize">
-                        <Button.Template>
-                            <ControlTemplate TargetType="Button">
-                                <Border x:Name="minimizeBorder"
-                                        Background="Transparent"
-                                        BorderThickness="0"
-                                        BorderBrush="Transparent">
-                                    <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                </Border>
-                                <ControlTemplate.Triggers>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter TargetName="minimizeBorder" Property="Background" Value="{StaticResource BackgroundLightGray}"/>
-                                    </Trigger>
-                                    <Trigger Property="IsPressed" Value="True">
-                                        <Setter TargetName="minimizeBorder" Property="Background" Value="{StaticResource BackgroundMediumLightGray}"/>
-                                    </Trigger>
-                                </ControlTemplate.Triggers>
-                            </ControlTemplate>
-                        </Button.Template>
-                    </Button>
-                    <Button Content="✕" Foreground="#f5f3f4" FontSize="16"  Width="40" Click="Close_Click">
-                        <Button.Template>
-                            <ControlTemplate TargetType="Button">
-                                <Border x:Name="minimizeBorder"
-                                        Background="Transparent"
-                                        BorderThickness="0"
-                                        BorderBrush="Transparent">
-                                    <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                </Border>
-                                <ControlTemplate.Triggers>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter TargetName="minimizeBorder" Property="Background" Value="{StaticResource CloseWindowRed}"/>
-                                    </Trigger>
-                                    <Trigger Property="IsPressed" Value="True">
-                                        <Setter TargetName="minimizeBorder" Property="Background" Value="{StaticResource BackgroundMediumLightGray}"/>
-                                    </Trigger>
-                                </ControlTemplate.Triggers>
-                            </ControlTemplate>
-                        </Button.Template>
-                    </Button>
-                </StackPanel>
-            </DockPanel>
-        </Border>
-
-        <!-- Window Content -->
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="300" />
-            </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
-                <RowDefinition Height="300"/>
+                <RowDefinition Height="40"/>
                 <RowDefinition Height="*"/>
-                <RowDefinition Height="60"/>
             </Grid.RowDefinitions>
 
-            <!-- Monitor canvas area -->
-            <Border Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Margin="30,10,30,10">
-                <Viewbox Stretch="Uniform" StretchDirection="DownOnly" HorizontalAlignment="Center" VerticalAlignment="Center">
-                    <Canvas Width="{Binding TotalCanvasWidth}" Height="{Binding TotalCanvasHeight}">
-                        <ItemsControl ItemsSource="{Binding Monitors}">
-                            <ItemsControl.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <Canvas />
-                                </ItemsPanelTemplate>
-                            </ItemsControl.ItemsPanel>
+            <!-- Custom Title Bar -->
+            <Border Grid.Row="0" Height="40" Background="{StaticResource BackgroundMediumLightGray}" MouseLeftButtonDown="OnTitleBarMouseLeftButtonDown">
+                <DockPanel LastChildFill="True">
+                    <!-- Title Logo -->
+                    <views:TitleLogo Height="20" Margin="10,0,0,0"/>
 
-                            <ItemsControl.ItemContainerStyle>
-                                <Style>
-                                    <Setter Property="Canvas.Left" Value="{Binding CanvasX}" />
-                                    <Setter Property="Canvas.Top" Value="{Binding CanvasY}" />
-                                </Style>
-                            </ItemsControl.ItemContainerStyle>
-
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate DataType="{x:Type vm:MonitorViewModel}">
-                                    <views:MonitorView />
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </Canvas>
-                </Viewbox>
-            </Border>
-
-            <Border Grid.Column="0" Grid.Row="1" Padding="10">
-                    <StackPanel DockPanel.Dock="Top">
-                        <TextBlock Text="Selected Layout"
-                                   FontWeight="Bold"
-                                   Foreground="{StaticResource TextWhite}"
-                                   FontSize="18"
-                                   Margin="10 0 0 10"/>
-
-                        <ItemsControl ItemsSource="{Binding SelectedTemplatePreview}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate DataType="{x:Type vm:ZoneTemplatePreviewViewModel}">
-                                    <views:ZoneTemplatePreviewView />
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-
-                        <!-- Settings Controls -->
-                        <StackPanel Margin="10,20,15,0">
-                            <TextBlock Text="Tile Hint Character Pool Seed"
-                                       ToolTip="The set of characters used by VoilaTile to create the hints for the enumerated tiles.&#x0a;Longer seeds result in shorter hints for a large amount of the defined tiles."
-                                       Foreground="{StaticResource TextWhite}"
-                                       FontWeight="Bold"
-                                       FontSize="14"
-                                       Margin="0,0,0,4"/>
-
-                            <TextBox Text="{Binding Settings.Seed, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                     Background="{StaticResource BackgroundLightGray}"
-                                     Foreground="{StaticResource TextWhite}"
-                                     BorderThickness="0"
-                                     Padding="6"/>
-
-                            <TextBlock Text="Snapper Shortcut Key"
-                                       ToolTip="The action key used in the shortcut for the opening of the VoilaTile.Snapper overlays.&#x0a;The full shortcut will have the form of Win + Shift + { Your selected key }."
-                                       Foreground="{StaticResource TextWhite}"
-                                       FontWeight="Bold"
-                                       FontSize="14"
-                                       Margin="0,10,0,4"/>
-
-                            <ComboBox ItemsSource="{Binding Settings.AvailableShortcutKeys}"
-                                      SelectedItem="{Binding Settings.SelectedShortcutKey, Mode=TwoWay}"
-                                      Height="28"
-                                      Style="{StaticResource ThemedComboBox}"/>
-                        </StackPanel>
+                    <!-- Window Buttons -->
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                        <Button Content="–" Foreground="{StaticResource TextWhite}" FontSize="18" Width="40" BorderBrush="Transparent" Click="OnClickMinimize">
+                            <Button.Template>
+                                <ControlTemplate TargetType="Button">
+                                    <Border x:Name="minimizeBorder"
+                                            Background="Transparent"
+                                            BorderThickness="0"
+                                            BorderBrush="Transparent">
+                                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="minimizeBorder" Property="Background" Value="{StaticResource BackgroundLightGray}"/>
+                                        </Trigger>
+                                        <Trigger Property="IsPressed" Value="True">
+                                            <Setter TargetName="minimizeBorder" Property="Background" Value="{StaticResource BackgroundMediumLightGray}"/>
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Button.Template>
+                        </Button>
+                        <Button Content="☐" Foreground="{StaticResource TextWhite}" FontSize="16"  Width="40" Click="OnClickMaximize">
+                            <Button.Template>
+                                <ControlTemplate TargetType="Button">
+                                    <Border x:Name="minimizeBorder"
+                                            Background="Transparent"
+                                            BorderThickness="0"
+                                            BorderBrush="Transparent">
+                                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="minimizeBorder" Property="Background" Value="{StaticResource BackgroundLightGray}"/>
+                                        </Trigger>
+                                        <Trigger Property="IsPressed" Value="True">
+                                            <Setter TargetName="minimizeBorder" Property="Background" Value="{StaticResource BackgroundMediumLightGray}"/>
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Button.Template>
+                        </Button>
+                        <Button Content="✕" Foreground="#f5f3f4" FontSize="16"  Width="40" Click="Close_Click">
+                            <Button.Template>
+                                <ControlTemplate TargetType="Button">
+                                    <Border x:Name="minimizeBorder"
+                                            Background="Transparent"
+                                            BorderThickness="0"
+                                            BorderBrush="Transparent">
+                                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="minimizeBorder" Property="Background" Value="{StaticResource CloseWindowRed}"/>
+                                        </Trigger>
+                                        <Trigger Property="IsPressed" Value="True">
+                                            <Setter TargetName="minimizeBorder" Property="Background" Value="{StaticResource BackgroundMediumLightGray}"/>
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Button.Template>
+                        </Button>
                     </StackPanel>
+                </DockPanel>
             </Border>
 
-            <Border Grid.Column="1" Grid.Row="1" Padding="10" Background="{StaticResource BackgroundMediumLightGray}">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
+            <!-- Window Content -->
+            <Grid Grid.Row="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="300" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="300"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="60"/>
+                </Grid.RowDefinitions>
 
-                    <TextBlock Text="Layout Templates"
-                   FontWeight="Bold"
-                   Foreground="{StaticResource TextWhite}"
-                   FontSize="18"
-                   Margin="10 0 0 6"/>
+                <!-- Monitor canvas area -->
+                <Border Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Margin="30,10,30,10">
+                    <Viewbox Stretch="Uniform" StretchDirection="DownOnly" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <Canvas Width="{Binding TotalCanvasWidth}" Height="{Binding TotalCanvasHeight}">
+                            <ItemsControl ItemsSource="{Binding Monitors}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <Canvas />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
 
-                    <ScrollViewer
-                      x:Name="TemplatePreviewsScrollViewer"
-                      Grid.Row="1"
-                      VerticalScrollBarVisibility="Auto"
-                      HorizontalScrollBarVisibility="Disabled"
-                      CanContentScroll="True"
-                      FocusVisualStyle="{x:Null}">
-                        <ItemsControl ItemsSource="{Binding TemplatePreviews}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate DataType="{x:Type vm:ZoneTemplatePreviewViewModel}">
-                                    <views:InteractableZoneTemplatePreviewView />
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </ScrollViewer>
-                </Grid>
-            </Border>
+                                <ItemsControl.ItemContainerStyle>
+                                    <Style>
+                                        <Setter Property="Canvas.Left" Value="{Binding CanvasX}" />
+                                        <Setter Property="Canvas.Top" Value="{Binding CanvasY}" />
+                                    </Style>
+                                </ItemsControl.ItemContainerStyle>
 
-            <!-- Selected Layout Panel Buttons -->
-            <Border Grid.Column="0" Grid.Row="2" Padding="10">
-                <StackPanel Orientation="Horizontal">
-                    <Button
-                        ToolTip="Edit the layout which is currently selected on the active monitor.&#x0a;The changes will propagate to other monitors using the same layout."
-                        Style="{StaticResource RoundedRectActionButton}" Background="{StaticResource AccentRed}" Width="135" Content="Edit Layout" Command="{Binding EditSelectedLayoutCommand}"/>
-                </StackPanel>
-            </Border>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type vm:MonitorViewModel}">
+                                        <views:MonitorView />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </Canvas>
+                    </Viewbox>
+                </Border>
 
-            <!-- Layout Templates Panel Buttons -->
-            <Border Grid.Column="1" Grid.Row="2" Padding="10" Background="{StaticResource BackgroundMediumLightGray}">
-                <StackPanel Orientation="Horizontal">
-                    <Button 
-                        ToolTip="Create a new template layout.&#x0a;The editor will be open on the active monitor."
-                        Style="{StaticResource RoundedRectActionButton}" Background="{StaticResource AccentRed}" Width="135" Content="New Template" Command="{Binding AddNewLayoutCommand}" Margin="0,0,10,0"/>
-                    <Button 
-                        ToolTip="Edit the selected template layout.&#x0a;The changes will propagate to other monitors using the same layout."
-                        Style="{StaticResource RoundedRectActionButton}" Background="{StaticResource AccentRed}" Width="135" Content="Edit Template" Command="{Binding EditLayoutCommand}"/>
-                </StackPanel>
-            </Border>
+                <Border Grid.Column="0" Grid.Row="1" Padding="10">
+                        <StackPanel DockPanel.Dock="Top">
+                            <TextBlock Text="Selected Layout"
+                                       FontWeight="Bold"
+                                       Foreground="{StaticResource TextWhite}"
+                                       FontSize="18"
+                                       Margin="10 0 0 10"/>
 
+                            <ItemsControl ItemsSource="{Binding SelectedTemplatePreview}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type vm:ZoneTemplatePreviewViewModel}">
+                                        <views:ZoneTemplatePreviewView />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+
+                            <!-- Settings Controls -->
+                            <StackPanel Margin="10,20,15,0">
+                                <TextBlock Text="Tile Hint Character Pool Seed"
+                                           ToolTip="The set of characters used by VoilaTile to create the hints for the enumerated tiles.&#x0a;Longer seeds result in shorter hints for a large amount of the defined tiles."
+                                           Foreground="{StaticResource TextWhite}"
+                                           FontWeight="Bold"
+                                           FontSize="14"
+                                           Margin="0,0,0,4"/>
+
+                                <TextBox Text="{Binding Settings.Seed, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         Background="{StaticResource BackgroundLightGray}"
+                                         Foreground="{StaticResource TextWhite}"
+                                         BorderThickness="0"
+                                         Padding="6"/>
+
+                                <TextBlock Text="Snapper Shortcut Key"
+                                           ToolTip="The action key used in the shortcut for the opening of the VoilaTile.Snapper overlays.&#x0a;The full shortcut will have the form of Win + Shift + { Your selected key }."
+                                           Foreground="{StaticResource TextWhite}"
+                                           FontWeight="Bold"
+                                           FontSize="14"
+                                           Margin="0,10,0,4"/>
+
+                                <ComboBox ItemsSource="{Binding Settings.AvailableShortcutKeys}"
+                                          SelectedItem="{Binding Settings.SelectedShortcutKey, Mode=TwoWay}"
+                                          Height="28"
+                                          Style="{StaticResource ThemedComboBox}"/>
+                            </StackPanel>
+                        </StackPanel>
+                </Border>
+
+                <Border Grid.Column="1" Grid.Row="1" Padding="10" Background="{StaticResource BackgroundMediumLightGray}">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Text="Layout Templates"
+                       FontWeight="Bold"
+                       Foreground="{StaticResource TextWhite}"
+                       FontSize="18"
+                       Margin="10 0 0 6"/>
+
+                        <ScrollViewer
+                          x:Name="TemplatePreviewsScrollViewer"
+                          Grid.Row="1"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled"
+                          CanContentScroll="True"
+                          FocusVisualStyle="{x:Null}">
+                            <ItemsControl ItemsSource="{Binding TemplatePreviews}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type vm:ZoneTemplatePreviewViewModel}">
+                                        <views:InteractableZoneTemplatePreviewView />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+                    </Grid>
+                </Border>
+
+                <!-- Selected Layout Panel Buttons -->
+                <Border Grid.Column="0" Grid.Row="2" Padding="10">
+                    <StackPanel Orientation="Horizontal">
+                        <Button
+                            ToolTip="Edit the layout which is currently selected on the active monitor.&#x0a;The changes will propagate to other monitors using the same layout."
+                            Style="{StaticResource RoundedRectActionButton}" Background="{StaticResource AccentRed}" Width="135" Content="Edit Layout" Command="{Binding EditSelectedLayoutCommand}"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Layout Templates Panel Buttons -->
+                <Border Grid.Column="1" Grid.Row="2" Padding="10" Background="{StaticResource BackgroundMediumLightGray}">
+                    <StackPanel Orientation="Horizontal">
+                        <Button 
+                            ToolTip="Create a new template layout.&#x0a;The editor will be open on the active monitor."
+                            Style="{StaticResource RoundedRectActionButton}" Background="{StaticResource AccentRed}" Width="135" Content="New Template" Command="{Binding AddNewLayoutCommand}" Margin="0,0,10,0"/>
+                        <Button 
+                            ToolTip="Edit the selected template layout.&#x0a;The changes will propagate to other monitors using the same layout."
+                            Style="{StaticResource RoundedRectActionButton}" Background="{StaticResource AccentRed}" Width="135" Content="Edit Template" Command="{Binding EditLayoutCommand}"/>
+                    </StackPanel>
+                </Border>
+
+            </Grid>
         </Grid>
-    </Grid>
+    </Viewbox>
 
 </Window>
 

--- a/VoilaTile.Configurator/MainWindow.xaml.cs
+++ b/VoilaTile.Configurator/MainWindow.xaml.cs
@@ -81,13 +81,13 @@
             var confirmExitDialog = new ConfirmationDialogViewModel("Confirm Exit", "Are you sure you have finished setting up your layouts?\nOn exit the layouts will be persisted.");
             var (result, _) = await App.DialogService.ShowAsync(confirmExitDialog);
 
-            // Ask the view model to check if the snapper is running.
-            await this.viewModel.CheckSnapperRunningAsync();
-
             if (result == DialogDecision.Negative)
             {
                 return;
             }
+
+            // Ask the view model to check if the snapper is running.
+            await this.viewModel.CheckSnapperRunningAsync();
 
             OverlayManager.HideOverlay();
             this.Close();

--- a/VoilaTile.Configurator/ViewModels/LayoutEditor/LayoutEditorViewModel.cs
+++ b/VoilaTile.Configurator/ViewModels/LayoutEditor/LayoutEditorViewModel.cs
@@ -69,8 +69,6 @@
         public LayoutEditorViewModel(ZoneTemplate template)
         {
             this.editedTemplate = template;
-            this.InitializeDividers(template);
-            this.AttachDividerEventHandlers();
         }
 
         #endregion Constructors
@@ -119,6 +117,12 @@
         #endregion Properties
 
         #region Methods
+
+        public void Initialize()
+        {
+            this.InitializeDividers(this.editedTemplate);
+            this.AttachDividerEventHandlers();
+        }
 
         public ZoneTemplate ToZoneTemplate()
         {

--- a/VoilaTile.Configurator/Views/LayoutEditor/LayoutEditorWindow.xaml.cs
+++ b/VoilaTile.Configurator/Views/LayoutEditor/LayoutEditorWindow.xaml.cs
@@ -37,6 +37,11 @@
             this.MouseMove += OnMouseMove;
             this.MouseLeftButtonDown += OnMouseLeftButtonDown;
             this.MouseLeftButtonUp += OnMouseLeftButtonUp;
+        }
+
+        public void Initialize()
+        {
+            this.viewModel.Initialize();
 
             this.UpdateGridLayout();
             this.UpdateZoneLabels();


### PR DESCRIPTION
Problems:
- configurator layout editor view and view model were initializing in their respective constructor causing the divider component to inherit the original canvas size (1, 1)

Fixes:
- separated the creation and initialization logic of the layout editor view and view model
- ensured the layout editor view and view model are initialized after creation and sizing of the layout editor overlay window

Testing:
- 2-monitor setup: (150, 150)%, (100, 125)%, (100, 100)% scaling
- Deleted and recreated existing layouts
- Verified correctness of layout rendering in layout editor when modifying after creation (through "Edit Layout" functionality)

